### PR TITLE
Updating the Autoconfiguration Script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ -n "$DOKKU_POSTGRES_AQUA_URL" ]; then
+DATABASE_URL="$DOKKU_POSTGRES_AQUA_URL"
+fi
+
 export JDBC_DATABASE_PASSWORD=$(echo "$DATABASE_URL" | cut --delimiter=: -f3 | cut --delimiter=\@ -f1)
 
 export JDBC_DATABASE_URL=jdbc:postgresql://$(echo "$DATABASE_URL" | cut --delimiter=\@ -f2)


### PR DESCRIPTION
In this PR, I update the Postgres autoconfiguration script to account for the DOKKU_POSTGRES_AQUA_URL.

Previously, if the DATABASE_URL was blank, it would fail. However, now if there is an AQUA_URL, it takes priority.