### PR TITLE
Setting the NPM Engine Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ frontend/reports
 
 frontend/storybook-static
 
+# Don't check storybook builds
+build-storybook.log
+
 # If a package-lock.json shows up in top level dir, don't store it in github
 # Only keep the one under frontend/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 RUN java -version
 RUN curl --version
 
-ENV NODE_VERSION=20.17.0
+ENV NODE_VERSION=22.14.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}

--- a/README.md
+++ b/README.md
@@ -51,23 +51,23 @@ Then:
 * In the second window:
   ```
   cd frontend
-  nvm install 20.17.0
-  nvm use 20.17.0
+  nvm install 22.14.0
+  nvm use 22.14.0
   npm ci  
   npm start
   ```
 The app should be available on <http://localhost:8080>
 
 A few notes:
-* The `nvm install 20.17.0` command is only needed once per system.
-* The `nvm use 20.17.0` command is only needed once per terminal session
+* The `nvm install 22.14.0` command is only needed once per system.
+* The `nvm use 22.14.0` command is only needed once per terminal session
 * The `npm ci` command (`ci` is for `clean install` is typically only needed on your first run.
 
 So subsequent runs of the frontend are typically:
 
 ```
 cd frontend
-nvm use 20.17.0
+nvm use 22.14.0
 npm start
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@chromatic-com/storybook": "^1.7.0",
         "@testing-library/dom": "^8.11.3",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.5",
@@ -15,6 +16,7 @@
         "axios": "^0.21.1",
         "babel-loader": "8.1.0",
         "bootstrap": "^5.0.0-beta3",
+        "chromatic": "^11.25.2",
         "history": "^5.0.0",
         "nock": "^13.2.4",
         "react": "^17.0.1",
@@ -51,7 +53,7 @@
         "react-test-renderer": "^17.0.2"
       },
       "engines": {
-        "node": "=16.20.0"
+        "node": "=20.17.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1986,6 +1988,59 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "node_modules/@chromatic-com/storybook": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-1.7.0.tgz",
+      "integrity": "sha512-0aAkSaNsHaJL37/r+TIbpKjCouIysvoJno61LzUSs1xW4fpxF7gdr8xwIOONQjEsz2Fa0uFHXmzkFYcH6o8kmA==",
+      "license": "MIT",
+      "dependencies": {
+        "chromatic": "^11.4.0",
+        "filesize": "^10.0.12",
+        "jsonfile": "^6.1.0",
+        "react-confetti": "^6.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "yarn": ">=1.22.18"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/filesize": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
+      "integrity": "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.4.0"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -14520,6 +14575,29 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "11.25.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.25.2.tgz",
+      "integrity": "sha512-/9eQWn6BU1iFsop86t8Au21IksTRxwXAl7if8YHD05L2AbuMjClLWZo5cZojqrJHGKDhTqfrC2X2xE4uSm0iKw==",
+      "license": "MIT",
+      "bin": {
+        "chroma": "dist/bin.js",
+        "chromatic": "dist/bin.js",
+        "chromatic-cli": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@chromatic-com/cypress": {
+          "optional": true
+        },
+        "@chromatic-com/playwright": {
+          "optional": true
+        }
       }
     },
     "node_modules/chrome-trace-event": {
@@ -27674,6 +27752,21 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -33485,6 +33578,12 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -36994,6 +37093,38 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "@chromatic-com/storybook": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-1.7.0.tgz",
+      "integrity": "sha512-0aAkSaNsHaJL37/r+TIbpKjCouIysvoJno61LzUSs1xW4fpxF7gdr8xwIOONQjEsz2Fa0uFHXmzkFYcH6o8kmA==",
+      "requires": {
+        "chromatic": "^11.4.0",
+        "filesize": "^10.0.12",
+        "jsonfile": "^6.1.0",
+        "react-confetti": "^6.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
+        },
+        "filesize": {
+          "version": "10.1.6",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
+          "integrity": "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w=="
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -46645,6 +46776,12 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
+    },
+    "chromatic": {
+      "version": "11.25.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.25.2.tgz",
+      "integrity": "sha512-/9eQWn6BU1iFsop86t8Au21IksTRxwXAl7if8YHD05L2AbuMjClLWZo5cZojqrJHGKDhTqfrC2X2xE4uSm0iKw==",
+      "requires": {}
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -56599,6 +56736,14 @@
       "dev": true,
       "requires": {}
     },
+    "react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "requires": {
+        "tween-functions": "^1.2.0"
+      }
+    },
     "react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -60888,6 +61033,11 @@
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
+    },
+    "tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "=20.17.0"
+    "node": ">=22.14.0"
   },
   "dependencies": {
+    "@chromatic-com/storybook": "^1.7.0",
     "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
@@ -13,6 +14,7 @@
     "axios": "^0.21.1",
     "babel-loader": "8.1.0",
     "bootstrap": "^5.0.0-beta3",
+    "chromatic": "^11.25.2",
     "history": "^5.0.0",
     "nock": "^13.2.4",
     "react": "^17.0.1",

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v20.17.0</nodeVersion>
+                                    <nodeVersion>v22.14.0</nodeVersion>
                                 </configuration>
                             </execution>
                             <execution>
@@ -409,7 +409,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v20.17.0</nodeVersion>
+                                    <nodeVersion>v22.14.0</nodeVersion>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
In this PR, I add `chromatic` and `chromatic-com/storybook` with package versions that match team02's. These changes are documented in package-lock.json, and I bump the node engine version to the latest lts, 22.14.0. 

All tests successfully pass after upgrade. Deployed to https://jpa03-division7.dokku-00.cs.ucsb.edu/